### PR TITLE
New config value and more logging

### DIFF
--- a/StrategicOperations/StrategicOperations/Framework/BattleArmorUtils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/BattleArmorUtils.cs
@@ -445,6 +445,19 @@ namespace StrategicOperations.Framework
             {
                 point = validPoints.GetRandomElement();
                 point.y = actor.Combat.MapMetaData.GetLerpedHeightAt(point, false);
+                if (Mathf.Approximately(point.x, actor.CurrentPosition.x) && Mathf.Approximately(point.z, actor.CurrentPosition.z))
+                {
+                    ModInit.modLog?.Warn?.Write($"[FetchRandomAdjacentHex] Picked same position {point} as current position {actor.CurrentPosition}");
+                }
+            }
+            else
+            {
+                ModInit.modLog?.Warn?.Write("[FetchRandomAdjacentHex] No valid nearby position found, will plonk on same hex causing a stacked unit.");
+                ModInit.modLog?.Warn?.Write($"  Current position is {point}. Adjacent points were: ");
+                foreach (Vector3 vector3 in points)
+                {
+                    ModInit.modLog?.Warn?.Write($"    {vector3}");
+                }
             }
             return point;
         }
@@ -1052,6 +1065,7 @@ namespace StrategicOperations.Framework
 
                     var internalCap = carrier.GetInternalBACap();
                     var currentInternalSquads = carrier.GetInternalBASquads();
+                    var hud = CameraControl.Instance.HUD;
                     if (currentInternalSquads < internalCap)
                     {
                         ModInit.modLog?.Info?.Write($"[MountBattleArmorToChassis] - target unit {carrier.DisplayName} has internal BA capacity of {internalCap}. Currently used: {currentInternalSquads}, mounting squad internally.");
@@ -1060,7 +1074,6 @@ namespace StrategicOperations.Framework
                         // try and set firing arc to 360?
                         battleArmor.FiringArc(360f);
                         //refresh firing button state to make sure firing ports are respected
-                        var hud = CameraControl.Instance.HUD;
                         if (isPlayer && battleArmor == hud.selectedUnit && !carrier.HasFiringPorts())
                         {
                             CameraControl.Instance.HUD.MechWarriorTray.FireButton.DisableButton();
@@ -1657,7 +1670,9 @@ namespace StrategicOperations.Framework
                     $"[Ability.Activate - BattleArmorSwarmID] Cleaning up dummy attacksequence.");
                 ModInit.modLog?.Info?.Write(
                     $"[Ability.Activate - BattleArmorSwarmID] No hits in HitInfo, plonking unit at adjacent hex.");
-                creatorMech.TeleportActor(targetActor.FetchRandomAdjacentHex());
+                Vector3 fetchRandomAdjacentHex = targetActor.FetchRandomAdjacentHex();
+                ModInit.modLog?.Debug?.Write($"[Ability.Activate - BattleArmorSwarmID]   Swarming Position: {targetActor.CurrentPosition}  Selected Random Adjacent Hex: {fetchRandomAdjacentHex}");
+                creatorMech.TeleportActor(fetchRandomAdjacentHex);
                 creatorMech.ResetPathing(false);
                 creatorMech.Pathing.UpdateCurrentPath(false);
                 if (creatorMech.team.IsLocalPlayer)

--- a/StrategicOperations/StrategicOperations/ModInit.cs
+++ b/StrategicOperations/StrategicOperations/ModInit.cs
@@ -104,6 +104,7 @@ namespace StrategicOperations
         public bool ExternalBAAffectsSlotDropTonnage = true;
         public List<BA_FactionAssoc> BattleArmorFactionAssociations = new List<BA_FactionAssoc>();
         public string BattleArmorMountAndSwarmID = "";
+        public bool BattleArmorHandsyOverridesInternalOnly = false;
 
         public Dictionary<string, ConfigOptions.BeaconExclusionConfig> BeaconExclusionConfig =
             new Dictionary<string, ConfigOptions.BeaconExclusionConfig>();

--- a/StrategicOperations/StrategicOperations/Patches/SelectionPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/SelectionPatches.cs
@@ -105,7 +105,9 @@ namespace StrategicOperations.Patches
                             }
 
                             if (!SelectedActor.IsMountedUnit() && SelectedActor.CanRideInternalOnly() &&
-                                targetActor.GetAvailableInternalBASpace() <= 0)
+                                targetActor.GetAvailableInternalBASpace() <= 0 &&
+                                (!ModInit.modSettings.BattleArmorHandsyOverridesInternalOnly ||
+                                 !SelectedActor.GetIsBattleArmorHandsy()))
                             {
                                 return false;
                             }


### PR DESCRIPTION
* Added configuration to change friendly squad carrier selection logic to give **IsBattleArmorHandsy** precedence over **BattleArmorInternalMountsOnly**, allowing units with _Handsy_ enabled to mount externally even if some other gear says _Internal Only_
* Added more logging for issues with swarming failed position