### PR TITLE
Perf Improvements:

### DIFF
--- a/StrategicOperations/StrategicOperations/Framework/Classes.cs
+++ b/StrategicOperations/StrategicOperations/Framework/Classes.cs
@@ -716,7 +716,6 @@ namespace StrategicOperations.Framework
                 newBattleArmor.Init(Actor.CurrentPosition, Actor.CurrentRotation.eulerAngles.y, true);
                 newBattleArmor.InitGameRep(null);
                 TeamSelection.AddUnit(newBattleArmor);
-                //newBattleArmor.AddToTeam(TeamSelection);
                 newBattleArmor.AddToLance(CustomLance);
                 CustomLance.AddUnitGUID(newBattleArmor.GUID);
                 newBattleArmor.BehaviorTree = BehaviorTreeFactory.MakeBehaviorTree(

--- a/StrategicOperations/StrategicOperations/Framework/ResupplyUtils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/ResupplyUtils.cs
@@ -12,6 +12,9 @@ namespace StrategicOperations.Framework
 {
     public static class ResupplyUtils
     {
+        
+        public const string ResupplyUnitStat = "IsResupplyUnit";
+        
         public static bool AreAnyWeaponsOutOfAmmo(this AbstractActor actor)
         {
             foreach (var weapon in actor.Weapons)
@@ -23,13 +26,13 @@ namespace StrategicOperations.Framework
 
         public static AbstractActor GetClosestDetectedResupply(this AbstractActor actor)
         {
-            var friendlyUnits = actor.team.VisibilityCache.GetAllFriendlies(actor).Where(x => !x.IsDead && !x.IsFlaggedForDeath);
+            var friendlyUnits = actor.team.VisibilityCache.GetAllFriendlies(actor);
             var num = -1f;
             var distance = -9999f;
             AbstractActor resupplyActor = null;
             foreach (var friendly in friendlyUnits)
             {
-                if (!friendly.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag)) continue;
+                if (!friendly.statCollection.GetValue<bool>(ResupplyUnitStat)) continue;
                 distance = Vector3.Distance(actor.CurrentPosition, friendly.CurrentPosition);
                 if (num < 0f || distance < num)
                 {
@@ -42,12 +45,12 @@ namespace StrategicOperations.Framework
 
         public static float GetDistanceToClosestDetectedResupply(this AbstractActor actor, Vector3 position)
         {
-            var friendlyUnits = actor.team.VisibilityCache.GetAllFriendlies(actor).Where(x => !x.IsDead && !x.IsFlaggedForDeath);
+            var friendlyUnits = actor.team.VisibilityCache.GetAllFriendlies(actor);
             var num = -1f;
             var magnitude = -9999f;
             foreach (var friendly in friendlyUnits)
             {
-                if (!friendly.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag)) continue;
+                if (!friendly.statCollection.GetValue<bool>(ResupplyUnitStat)) continue;
                 magnitude = (position - friendly.CurrentPosition).magnitude;
                 if (num < 0f || magnitude < num)
                 {
@@ -321,7 +324,7 @@ namespace StrategicOperations.Framework
             foreach (var unit in actors)
             {
                 if (!ModState.TeamsWithResupply.Contains(unit.team.GUID)) continue;
-                if (unit.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag)) continue;
+                if (unit.statCollection.GetValue<bool>(ResupplyUnitStat)) continue;
                 if (unit.GetPilot().Abilities
                         .All(x => x.Def.Id != ModInit.modSettings.ResupplyConfig.ResupplyAbilityID) &&
                     unit.ComponentAbilities.All(y =>
@@ -343,7 +346,7 @@ namespace StrategicOperations.Framework
         {
             foreach (var actor in combat.GetAllLivingActors())
             {
-                if (actor.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag))
+                if (actor.statCollection.GetValue<bool>(ResupplyUnitStat))
                 {
                     foreach (var team in combat.Teams)
                     {

--- a/StrategicOperations/StrategicOperations/Framework/Utils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/Utils.cs
@@ -928,8 +928,7 @@ namespace StrategicOperations.Framework
 
         public static AbstractActor GetClosestDetectedEnemy(this AbstractActor actor, Vector3 loc)
         {
-            var enemyUnits = new List<AbstractActor>();
-            enemyUnits.AddRange(actor.team.VisibilityCache.GetAllDetectedEnemies(actor).Where(x=>!x.IsDead && !x.IsFlaggedForDeath));
+            var enemyUnits = actor.team.VisibilityCache.GetAllDetectedEnemies(actor);
             var num = -1f;
             AbstractActor closestActor = null;
             foreach (var enemy in enemyUnits)
@@ -946,7 +945,7 @@ namespace StrategicOperations.Framework
 
         public static AbstractActor GetClosestDetectedFriendly(Vector3 loc, AbstractActor actor)
         {
-            var friendlyUnits = actor.team.VisibilityCache.GetAllFriendlies(actor).Where(x=> !x.IsDead && !x.IsFlaggedForDeath);
+            var friendlyUnits = actor.team.VisibilityCache.GetAllFriendlies(actor);
             var num = -1f;
             AbstractActor closestActor = null;
             foreach (var friendly in friendlyUnits)
@@ -963,8 +962,7 @@ namespace StrategicOperations.Framework
 
         public static AbstractActor GetClosestDetectedSwarmTarget(this AbstractActor actor, Vector3 loc)
         {
-            var enemyUnits = new List<AbstractActor>();
-            enemyUnits.AddRange(actor.team.VisibilityCache.GetAllDetectedEnemies(actor).Where(x => !x.IsDead && !x.IsFlaggedForDeath));
+             var enemyUnits =actor.team.VisibilityCache.GetAllDetectedEnemies(actor);
             var num = -1f;
             AbstractActor closestActor = null;
             foreach (var enemy in enemyUnits)

--- a/StrategicOperations/StrategicOperations/Patches/SelectionPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/SelectionPatches.cs
@@ -41,7 +41,7 @@ namespace StrategicOperations.Patches
 
                 if (FromButton.Ability.Def.Id == ModInit.modSettings.ResupplyConfig.ResupplyAbilityID)
                 {
-                    if (potentialTarget is AbstractActor targetActor && targetActor.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag))
+                    if (potentialTarget is AbstractActor targetActor && targetActor.statCollection.GetValue<bool>(ResupplyUtils.ResupplyUnitStat))
                     {
                         return true;
                     }

--- a/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
@@ -1053,6 +1053,7 @@ namespace StrategicOperations.Patches
                 __instance.StatCollection.AddStatistic<bool>("OverrideGlobalCapacity", false);
                 __instance.StatCollection.AddStatistic<float>("AAAFactor", 0f);
                 __instance.StatCollection.AddStatistic<bool>("UseAAAFactor", false);
+                __instance.StatCollection.AddStatistic<bool>(ResupplyUtils.ResupplyUnitStat, false);
             }
         }
 
@@ -2907,6 +2908,13 @@ namespace StrategicOperations.Patches
         {
             public static void Postfix(Team __instance, AbstractActor unit)
             {
+                
+                if (unit.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag))
+                {
+                    unit.statCollection.Set(ResupplyUtils.ResupplyUnitStat, true);
+                }
+                
+                
                 if (__instance.Combat.TurnDirector.CurrentRound > 1)
                 {
                     __instance.Combat.UpdateResupplyTeams();

--- a/StrategicOperations/StrategicOperations/StrategicOperations.csproj
+++ b/StrategicOperations/StrategicOperations/StrategicOperations.csproj
@@ -33,8 +33,8 @@
   <PropertyGroup>
     <!-- avoids IgnoresAccessChecksToAttribute warnings -->
     <PublicizerRuntimeStrategies>Unsafe</PublicizerRuntimeStrategies>
-    <AssemblyVersion>3.1.3.4</AssemblyVersion>
-    <FileVersion>3.1.3.4</FileVersion>
+    <AssemblyVersion>3.1.4.0</AssemblyVersion>
+    <FileVersion>3.1.4.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Framework\Logger.cs" />


### PR DESCRIPTION
StratOps (in particular Resupply helper methods) is showing high up in perf flame graphs of AI think time. Alot of time is spent:
 - Creating and updating TagSets
 - checking if a TagSet contains a resupply tag

 To fix this:
 - add a new resupply unit stat to the actor's stat collection
 - on add unit, check the actor's tags, if resupply tag is present, mark it as a resupply unit.
 - remove all other checks for the resupply tag, check the stat instead. This stops tagset duplication and reduces checks for its existence to a single Dictionary lookup and boolean check, instead of iterating over a list.
 - Found that `GetAllFriendlies` & `GetAllDetectedEnemies` methods already filter out dead and marked for death units, removed spots where the output of these methods is filtered via linq on these same criteria, avoiding a new enumerable being created, filtered and calls that consume time checking if a unit is dead.

 Overall the hope is that this creates a noticable improvement to combat/AI perf.

 Notes for future:
 - See if there is away to improve `GetAllFriendlies` & `GetAllDetectedEnemies`, maybe caching or something? they are frequently called and do a fair number of checks and list creation overhead.