### PR TITLE
More perf fixes:

### DIFF
--- a/StrategicOperations/StrategicOperations/Framework/BattleArmorUtils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/BattleArmorUtils.cs
@@ -106,8 +106,9 @@ namespace StrategicOperations.Framework
 
         public static bool CanSwarm(this AbstractActor actor)
         {
-            if (actor != null && actor.GetStaticUnitTags().Contains(ModInit.modSettings.DisableAISwarmTag) && actor.team is AITeam) return false;
-            return actor != null && actor.StatCollection.GetValue<bool>("CanSwarm");
+            if (actor == null) return false;
+            if (actor.SwarmingDisabled && actor.team is AITeam) return false;
+            return actor.StatCollection.GetValue<bool>("CanSwarm");
         }
 
         public static void CheckForBPodAndActivate(this AbstractActor actor)

--- a/StrategicOperations/StrategicOperations/Framework/ResupplyUtils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/ResupplyUtils.cs
@@ -32,7 +32,7 @@ namespace StrategicOperations.Framework
             AbstractActor resupplyActor = null;
             foreach (var friendly in friendlyUnits)
             {
-                if (!friendly.statCollection.GetValue<bool>(ResupplyUnitStat)) continue;
+                if (!friendly.IsResupplyUnit) continue;
                 distance = Vector3.Distance(actor.CurrentPosition, friendly.CurrentPosition);
                 if (num < 0f || distance < num)
                 {
@@ -50,7 +50,7 @@ namespace StrategicOperations.Framework
             var magnitude = -9999f;
             foreach (var friendly in friendlyUnits)
             {
-                if (!friendly.statCollection.GetValue<bool>(ResupplyUnitStat)) continue;
+                if (!friendly.IsResupplyUnit) continue;
                 magnitude = (position - friendly.CurrentPosition).magnitude;
                 if (num < 0f || magnitude < num)
                 {
@@ -324,7 +324,7 @@ namespace StrategicOperations.Framework
             foreach (var unit in actors)
             {
                 if (!ModState.TeamsWithResupply.Contains(unit.team.GUID)) continue;
-                if (unit.statCollection.GetValue<bool>(ResupplyUnitStat)) continue;
+                if (unit.IsResupplyUnit) continue;
                 if (unit.GetPilot().Abilities
                         .All(x => x.Def.Id != ModInit.modSettings.ResupplyConfig.ResupplyAbilityID) &&
                     unit.ComponentAbilities.All(y =>
@@ -346,7 +346,7 @@ namespace StrategicOperations.Framework
         {
             foreach (var actor in combat.GetAllLivingActors())
             {
-                if (actor.statCollection.GetValue<bool>(ResupplyUnitStat))
+                if (actor.IsResupplyUnit)
                 {
                     foreach (var team in combat.Teams)
                     {

--- a/StrategicOperations/StrategicOperations/Framework/Utils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/Utils.cs
@@ -877,9 +877,9 @@ namespace StrategicOperations.Framework
         public static List<AbstractActor> GetAllFriendlies (this SharedVisibilityCache cache, AbstractActor actor)
         {
             var friendlyActors = new List<AbstractActor>();
-            foreach (var friendly in actor.Combat.GetAllLivingActors())
+            foreach (var friendly in actor.Combat.allActors)
             {
-                if (actor.team.IsFriendly(friendly.team) && !friendly.IsDead && !friendly.IsFlaggedForDeath)
+                if (!friendly.IsDead && actor.team.IsFriendly(friendly.team) && !friendly.IsFlaggedForDeath)
                 {
                     ModInit.modLog?.Debug?.Write($"unit {friendly.DisplayName} is friendly of {actor.DisplayName}.");
                     friendlyActors.Add(friendly);

--- a/StrategicOperations/StrategicOperations/Patches/SelectionPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/SelectionPatches.cs
@@ -41,7 +41,7 @@ namespace StrategicOperations.Patches
 
                 if (FromButton.Ability.Def.Id == ModInit.modSettings.ResupplyConfig.ResupplyAbilityID)
                 {
-                    if (potentialTarget is AbstractActor targetActor && targetActor.statCollection.GetValue<bool>(ResupplyUtils.ResupplyUnitStat))
+                    if (potentialTarget is AbstractActor targetActor && targetActor.IsResupplyUnit)
                     {
                         return true;
                     }

--- a/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
@@ -1054,6 +1054,8 @@ namespace StrategicOperations.Patches
                 __instance.StatCollection.AddStatistic<float>("AAAFactor", 0f);
                 __instance.StatCollection.AddStatistic<bool>("UseAAAFactor", false);
                 __instance.StatCollection.AddStatistic<bool>(ResupplyUtils.ResupplyUnitStat, false);
+                
+                __instance.SwarmingDisabled = __instance.GetStaticUnitTags().Contains(ModInit.modSettings.DisableAISwarmTag);
             }
         }
 
@@ -2912,6 +2914,7 @@ namespace StrategicOperations.Patches
                 if (unit.GetStaticUnitTags().Contains(ModInit.modSettings.ResupplyConfig.ResupplyUnitTag))
                 {
                     unit.statCollection.Set(ResupplyUtils.ResupplyUnitStat, true);
+                    unit.IsResupplyUnit = true;
                 }
                 
                 
@@ -3284,6 +3287,17 @@ namespace StrategicOperations.Patches
                         __instance.MountedEvasion(carrier);
                     }
                 }
+            }
+        }
+        
+        [HarmonyPatch(typeof(AbstractActor), "Hydrate")]
+        public static class AbstractActor_Hydrate_Patch
+        {
+            public static void Postfix(AbstractActor __instance)
+            {
+                __instance.IsResupplyUnit = __instance.StatCollection.GetValue<bool>(ResupplyUtils.ResupplyUnitStat);
+                __instance.SwarmingDisabled = __instance.GetStaticUnitTags().Contains(ModInit.modSettings.DisableAISwarmTag);
+
             }
         }
     }

--- a/StrategicOperations/StrategicOperationsInjector/ModTek/Injectors/ModTekSimpleInjector.StrategicOperations.xml
+++ b/StrategicOperations/StrategicOperationsInjector/ModTek/Injectors/ModTekSimpleInjector.StrategicOperations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ModTekSimpleInjector>
+    <AddField ToType="BattleTech.AbstractActor" InAssembly="Assembly-CSharp"
+              Name="IsResupplyUnit" OfType="System.Boolean"/>
+    <AddField ToType="BattleTech.AbstractActor" InAssembly="Assembly-CSharp"
+              Name="SwarmingDisabled" OfType="System.Boolean"/>
+    
+</ModTekSimpleInjector>

--- a/StrategicOperations/StrategicOperationsInjector/StrategicOperationsInjector.csproj
+++ b/StrategicOperations/StrategicOperationsInjector/StrategicOperationsInjector.csproj
@@ -57,6 +57,9 @@
     <Compile Include="Log.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="ModTek\Injectors\ModTekSimpleInjector.StrategicOperations.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
 		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(BattleTechGameDir)\Mods\ModTek\Injectors" Condition="'$(BattleTechGameDir)' != '' And Exists('$(BattleTechGameDir)\Mods\ModTek\Injectors')" />


### PR DESCRIPTION
- BA was also using a tagset to check if it could swarm, this is now replaced with an injected field for best perf.

- replaced resupply unit stats collection check with an injected field, this should further improve resupply perf.

- GetAllFriendlies is doing an unneeded IsDead check because GetAllLivingActors is already doing that. Given that it returns a new list and uses a findall, I swapped this instead for using the allActors property, so we only have to do 1 iteration over the list of actors. This also saves a new list being created and reduces the number of calls of IsDead by 1 per actor per call of GetAllFriendlies, which is frequently called.