### PR TITLE
Added alternate implementation of how to calculate the chance for preventing air strikes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ settings in the mod.json:
 	"strafeAltitudeMax": 250.0,
 	"strafePreDistanceMult": 15.0,
 	"strafeMinDistanceToEnd": 10.0,
+	"strafeUseAlternativeImplementation": false,
+    "strafeAAMaxCoverDistance": 1000,
+    "strafeFallbackStrengthValue": 5,
+    "strafeAttackerStrength": {},
 	"timeBetweenAttacks": 0.35,
 	"commandUseCostsMulti": 1.0,
 	"deploymentBeaconEquipment": [
@@ -575,6 +579,19 @@ settings in the mod.json:
 <s>"AI_FactionBeacons"`: essentially functions the same as `deploymentBeaconEquipment`, but restricts factions listed to the corresponding equipment. if a faction is not listed in here, it will use only the "default" unit listed in a given command ability.</s> **deprecated in 2.0.2.8**
 
 `commandAbilities_AI` - **Format Change in v2.0.2.8** - Changed to similar format as `BattleArmorFactionAssociations`. Can be used to give AI strafe and spawn (Beacon) abilities. Obviously the StrafeWaves field only applies to strafes, and will do nothing for beacons. MaxUsersAddedPerContract limit is based on only *this* ability, and is separate *per faction*. I.e, in a 3-way contract with you, ClanGhostBear and ClanWolf, both Ghost Bear and Wolf could get 3 units each with AbilityDefCMD_Strafe_AI.
+
+**new in v3.1.5.0** 
+Added a new alternate implementation for handling the calculation around prevented strafe attacks due to units in AA stance.
+
+The default implementation is based on the formula `Chance to cancel a strafe = <AAA Factor of all allied units in AA Stance> / <total allied units>`.
+
+With the new alternative implementation this is changed to `Chance to cancel a strafe = <AAA Factor of all allied units in AA Stance within range> / <the strength of the strafing unit>`.<br>
+
+The new settings for this alternative implementation are:
+* `strafeUseAlternativeImplementation` = enables the alternative implementation
+* `strafeAAMaxCoverDistance` = the max range a friendly unit can be at to help prevent the strafe. counted from the position of where the attacked unit is.
+* `strafeAttackerStrength` = mappings of the strength of each attacking unit, in the format of `"unitId": <strength (float)>"
+* `strafeFallbackStrengthValue` = if no mapping for the id of the attacking unit exists in the above setting, this fallback value is used
 
 **new in v3.1.1.0** 
 "ContractBlacklist" defines contract types and/or individual contract IDs for which this specific ability cannot be added to the AI

--- a/StrategicOperations/StrategicOperations/Framework/AI_Utils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/AI_Utils.cs
@@ -360,6 +360,13 @@ namespace StrategicOperations.Framework
             targetUnit = null;
             if (!CanStrafe(actor, out ability)) return 0;
             var assetID = AssignRandomSpawnAsset(ability, actor.team.FactionValue.Name, out var waves);
+
+            if (ModInit.modSettings.strafeUseAlternativeImplementation)
+            {
+                ModState.StrafeAttacker = assetID;
+                ModState.StrafeSelectedWaves = waves;
+            }
+
             var dmg = Mathf.RoundToInt(CalcExpectedDamage(actor, assetID) * waves);
 
             var targets = TargetsForStrafe(actor, ability,out startpoint, out endpoint, out targetUnit);

--- a/StrategicOperations/StrategicOperations/Framework/ModState.cs
+++ b/StrategicOperations/StrategicOperations/Framework/ModState.cs
@@ -107,6 +107,9 @@ namespace StrategicOperations.Framework
         public static List<VehicleChassisLocations> VehicleMountOrder = new List<VehicleChassisLocations>();
         public static List<LastUsedMounts> LastMounts = new List<LastUsedMounts>();
 
+        public static string StrafeAttacker = null; // AI Selected Strafe Attacker, only used for alternative strafing implementation
+        public static int StrafeSelectedWaves = 0; // AI selected amount of waves, only used for alternative strafing implementation
+
         public static void Initialize()
         {
             MechArmorMountOrder.Add(ArmorLocation.CenterTorso);
@@ -232,6 +235,8 @@ namespace StrategicOperations.Framework
             IsStrafeAOE = false;
             PlayerSpawnGUIDs = new List<string>();
             ReinitPhaseIcons = false;
+            StrafeAttacker = null;
+            StrafeSelectedWaves = 0;
         }
 
         public static void ResetDeferredBASpawners()

--- a/StrategicOperations/StrategicOperations/Framework/TB_StrafeSequence.cs
+++ b/StrategicOperations/StrategicOperations/Framework/TB_StrafeSequence.cs
@@ -313,7 +313,7 @@ namespace StrategicOperations.Framework
                     }
                     else if (cancelChanceFromAA == 0f)
                     {
-                        cancelChanceFromAA = allCombatants[i].GetAvoidStrafeChanceForTeam();
+                        cancelChanceFromAA = allCombatants[i].GetAvoidStrafeChanceForTeam(Attacker.Description.Id);
                     }
 
                     if (roll <= cancelChanceFromAA)

--- a/StrategicOperations/StrategicOperations/Framework/Utils.cs
+++ b/StrategicOperations/StrategicOperations/Framework/Utils.cs
@@ -949,20 +949,20 @@ namespace StrategicOperations.Framework
                     if (distance <= ModInit.modSettings.strafeAAMaxCoverDistance)
                     {
                         cumAA += unit.GetAAAFactor();
-                        ModInit.modLog?.Debug?.Write($"unit {unit.DisplayName} is friendly of {combatant.DisplayName} at distance {distance} which is within maximum cover distance of {ModInit.modSettings.strafeAAMaxCoverDistance}. " +
+                        ModInit.modLog?.Trace?.Write($"unit {unit.DisplayName} is friendly of {combatant.DisplayName} at distance {distance} which is within maximum cover distance of {ModInit.modSettings.strafeAAMaxCoverDistance}. " +
                                                      $"Added AA factor {unit.GetAAAFactor()}; total is now {cumAA}");
                     }
                 }
             }
 
-            if (!ModInit.modSettings.strafeAttackerStrength.TryGetValue(attackingUnitId, out var strafeAttackerDetermination))
+            if (!ModInit.modSettings.strafeAttackerStrength.TryGetValue(attackingUnitId, out var strafeAttackerStrength))
             {
-                ModInit.modLog?.Debug?.Write($"No strafe attacker strength found for {attackingUnitId}, using fallback.");
-                strafeAttackerDetermination = 5f;
+                ModInit.modLog?.Warn?.Write($"No strafe attacker strength found for {attackingUnitId}, using fallback.");
+                strafeAttackerStrength = ModInit.modSettings.strafeFallbackStrengthValue;
             }
 
-            var finalAA = cumAA / strafeAttackerDetermination;
-            ModInit.modLog?.Debug?.Write($"final AA value for {combatant.DisplayName} and team {combatant.team.DisplayName}: {finalAA}");
+            var finalAA = cumAA / strafeAttackerStrength;
+            ModInit.modLog?.Trace?.Write($"final AA value for {combatant.DisplayName} and team {combatant.team.DisplayName}: {finalAA}");
             return finalAA;
         }
 

--- a/StrategicOperations/StrategicOperations/ModInit.cs
+++ b/StrategicOperations/StrategicOperations/ModInit.cs
@@ -171,7 +171,9 @@ namespace StrategicOperations
         public bool spawnTurretEndsActivation = true;
         // ive strafing runs.
 
+        public bool strafeUseAlternativeImplementation = false; // if true, use the AA cover method based on cover unit distance and strafe unit strength
         public float strafeAAFailThreshold = 1f; //for AI strafes, if fail % is higher than this, they wont try
+        public float strafeAAMaxCoverDistance = 1000f;
         public float strafeAltitudeMax = 250f;
         public float strafeAltitudeMin = 75f;
         public bool strafeEndsActivation = true;
@@ -183,6 +185,7 @@ namespace StrategicOperations
         public float strafeTargetsFriendliesChance = 1f;
         public float strafeVelocityDefault = 150f;
         public int strafeWaves = 1; // strafes will spawn this many units and do
+        public Dictionary<string, float> strafeAttackerStrength = new Dictionary<string, float>(); // Used for alternative AA factor implementation
 
         public float timeBetweenAttacks = 0.35f;
 

--- a/StrategicOperations/StrategicOperations/ModInit.cs
+++ b/StrategicOperations/StrategicOperations/ModInit.cs
@@ -171,9 +171,7 @@ namespace StrategicOperations
         public bool spawnTurretEndsActivation = true;
         // ive strafing runs.
 
-        public bool strafeUseAlternativeImplementation = false; // if true, use the AA cover method based on cover unit distance and strafe unit strength
         public float strafeAAFailThreshold = 1f; //for AI strafes, if fail % is higher than this, they wont try
-        public float strafeAAMaxCoverDistance = 1000f;
         public float strafeAltitudeMax = 250f;
         public float strafeAltitudeMin = 75f;
         public bool strafeEndsActivation = true;
@@ -185,7 +183,10 @@ namespace StrategicOperations
         public float strafeTargetsFriendliesChance = 1f;
         public float strafeVelocityDefault = 150f;
         public int strafeWaves = 1; // strafes will spawn this many units and do
-        public Dictionary<string, float> strafeAttackerStrength = new Dictionary<string, float>(); // Used for alternative AA factor implementation
+        public bool strafeUseAlternativeImplementation = false; // if true, use the AA cover method based on cover unit distance and strafe unit strength
+        public float strafeAAMaxCoverDistance = 1000f; // Only used by alternative implementation
+        public float strafeFallbackStrengthValue = 5f; // Only used by alternative implementation
+        public Dictionary<string, float> strafeAttackerStrength = new Dictionary<string, float>(); // Only used by alternative implementation
 
         public float timeBetweenAttacks = 0.35f;
 

--- a/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
+++ b/StrategicOperations/StrategicOperations/Patches/StrategicOperationsPatches.cs
@@ -2719,7 +2719,8 @@ namespace StrategicOperations.Patches
                     var opforUnit = creator.FindMeAnOpforUnit();
                     if (opforUnit != null)
                     {
-                        ModState.CancelChanceForPlayerStrafe = opforUnit.GetAvoidStrafeChanceForTeam();
+                        var actorResource = __instance.FromButton.Ability.Def.ActorResource; // This is a player initiated strike, so strafe attacker should always be the one from the AbilityDef
+                        ModState.CancelChanceForPlayerStrafe = opforUnit.GetAvoidStrafeChanceForTeam(actorResource); // Actor resource is only used for alternative Strafe implementation
                     }
                     var chanceDisplay = (float)Math.Round(1 - ModState.CancelChanceForPlayerStrafe, 2) * 100;
                     cHUD.AttackModeSelector.FireButton.FireText.SetText($"{chanceDisplay}% - Confirm", Array.Empty<object>());

--- a/StrategicOperations/StrategicOperations/StrategicOperations.csproj
+++ b/StrategicOperations/StrategicOperations/StrategicOperations.csproj
@@ -33,8 +33,8 @@
   <PropertyGroup>
     <!-- avoids IgnoresAccessChecksToAttribute warnings -->
     <PublicizerRuntimeStrategies>Unsafe</PublicizerRuntimeStrategies>
-    <AssemblyVersion>3.1.4.0</AssemblyVersion>
-    <FileVersion>3.1.4.0</FileVersion>
+    <AssemblyVersion>3.1.5.0</AssemblyVersion>
+    <FileVersion>3.1.5.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Framework\Logger.cs" />


### PR DESCRIPTION
Added alternate implementation of how to calculate the chance for prevented air strafes. Based of only friendly units within range of the strafe attack start point (distance configurable) and the strength of the attacking unit performing the strafe (value configured in the mod.json).

Also added some caching of what actual unit the AI resolves to strike with, as it otherwise would use different randomized units for deciding if/where to attack and the actual attack.